### PR TITLE
fix: upgraded next-umami version issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.1.4",
-        "next-umami": "^0.0.4",
+        "next-umami": "^1.0.0",
         "phosphor-react": "^1.4.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -5364,10 +5364,17 @@
       }
     },
     "node_modules/next-umami": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/next-umami/-/next-umami-0.0.4.tgz",
-      "integrity": "sha512-v/sXVwvy+sumq3jPRkjiv1Tf7nk1HQxAjyohrc+x65QI6v5vFK2NG3NyI+C7ML41dYHDPg+UswUDDZu0yeGUWg==",
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-umami/-/next-umami-1.0.0.tgz",
+      "integrity": "sha512-bwq2nuH1vE0zBRkT/6pKznlKsDv6BwTWGfOFcSf0hLT3ua3OJHMVpB3Ws3GiCKl69Exan++PX05wNvfrDvfTmQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "next": ">=13.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "next": "15.1.4",
-    "next-umami": "^0.0.4",
+    "next-umami": "^1.0.0",
     "phosphor-react": "^1.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
Fixed next-umami@^0.0.4 target not found error during `npm install` by upgrading it to version next-umami@^1.0.0

```
npm error code ETARGET
npm error notarget No matching version found for next-umami@^0.0.4.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
```
