### PR TITLE
feat: add rss feed feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next-umami": "^1.0.0",
     "phosphor-react": "^1.4.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "rss": "^1.2.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
@@ -28,6 +29,7 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/rss": "^0.0.32",
     "eslint": "^9.18.0",
     "eslint-config-next": "^15.1.3",
     "eslint-plugin-react": "^7.37.3",

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+// This is for checking the site's aliveness access by some external apps
+
+export async function GET() {
+  return NextResponse.json({
+    message: 'pong'
+  });
+}

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -1,0 +1,70 @@
+import RSS from 'rss';
+import { NextResponse } from 'next/server';
+
+import Events from '@/data/events.json';
+import { SITE_URL } from '@/lib/constants';
+import { convertToIST } from '@/lib/common';
+import { Event } from '@/types/event';
+
+/**
+ * Generates the RSS feed for upcoming Tamil Nadu tech events.
+ * @returns {NextResponse} - Returns the RSS XML response with event data.
+ */
+export async function GET() {
+  const currentYear = new Date().getFullYear();
+  const feed = createRSSFeed(currentYear);
+
+  const sortedEvents = getSortedEvents();
+
+  if (sortedEvents.length) {
+    sortedEvents.forEach((event) => addEventToFeed(feed, event));
+  }
+
+  return new NextResponse(feed.xml({ indent: true }), {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' }
+  });
+}
+
+/**
+ * Creates the RSS feed object with required metadata.
+ * @param {number} year - The current year to use for copyright.
+ * @returns {RSS} - The RSS feed instance.
+ */
+const createRSSFeed = (year: number): RSS => {
+  return new RSS({
+    title: 'தமிழ்நாடு டெக் | Tamilnadu Tech',
+    description: 'Get All your Tamil Nadu Tech Meetups in one place',
+    feed_url: `${SITE_URL}/api/rss`,
+    site_url: SITE_URL,
+    copyright: `© ${year} Tamilnadu Tech`,
+    language: 'ta-IN | en-US',
+    pubDate: convertToIST(new Date().toUTCString()),
+    ttl: 60
+  });
+};
+
+/**
+ * Sorts events in descending order based on the event date.
+ * @returns {Events[]} - Sorted array of events.
+ */
+const getSortedEvents = (): Event[] =>
+  Events.sort((a, b) => convertToIST(b.eventDate).getTime() - convertToIST(a.eventDate).getTime());
+
+/**
+ * Adds a single event to the RSS feed.
+ * @param {RSS} feed - The RSS feed instance.
+ * @param {Event} event - The event data to be added to the feed.
+ */
+
+const addEventToFeed = (feed: RSS, event: Event): void => {
+  const istDate = new Date(
+    new Date(event.eventDate).toLocaleString('en-US', { timeZone: 'Asia/Kolkata' })
+  );
+
+  feed.item({
+    title: event.eventName,
+    description: event.eventDescription,
+    date: istDate,
+    url: event.eventLink
+  });
+};

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,0 +1,5 @@
+export const convertToIST = (dateStr: string) => {
+  const date = new Date(dateStr);
+  const IST_OFFSET = 5.5 * 60 * 60 * 1000; // 5 hours 30 minutes in milliseconds
+  return new Date(date.getTime() + IST_OFFSET);
+};

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -1,0 +1,11 @@
+export interface Event {
+  eventName: string;
+  eventDescription: string;
+  eventDate: string;
+  eventTime: string;
+  eventVenue: string;
+  eventLink: string;
+  location: string;
+  communityName: string;
+  communityLogo: string;
+}


### PR DESCRIPTION
Added RSS feed integration for Tamilnadu Tech events.

This feature allows users to access an RSS feed of all upcoming Tamil Nadu tech events. 
The feed includes event names, descriptions, dates, and event links.

## Changes:
- Added a new API route for generating RSS feeds.

## Screenshots
<img width="1440" alt="rss-1" src="https://github.com/user-attachments/assets/1d5fcaab-2cce-4d07-b5d5-1d13a604e73a" />
<img width="1440" alt="rss-2" src="https://github.com/user-attachments/assets/d843259e-9234-42a3-a43f-1aa1703b931b" />
<img width="1440" alt="rss-3" src="https://github.com/user-attachments/assets/c3237897-94e0-4cf5-9132-4f61d5a3e789" />
<img width="1440" alt="rss-4" src="https://github.com/user-attachments/assets/c0bbb770-8051-4451-8503-0915bc7ef85e" />

## Video
[chennaifoss-rss.webm](https://github.com/user-attachments/assets/4c20a0ce-9df6-45a4-bc71-e156bea070c1)
