### PR TITLE
Add: JSLovers Meetup Chennai on 05-04-2025

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -22,12 +22,12 @@
     "communityLogo": "https://res.cloudinary.com/startup-grind/image/upload/c_fill,w_500,h_500,g_center/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-cncf/events/Logo_White_Background_eSFH3vi.png"
   },
   {
-    "eventName": "JSLovers Chennai Meetup 4",
-    "eventDescription": "First Meetup of 2025 from JSLovers Chennai Chapter.",
-    "eventDate": "2025-02-08",
-    "eventTime": "02:00",
-    "eventVenue": "YuniQ, 4th Floor, Ticel Bio Park, Tharamani",
-    "eventLink": "https://lu.ma/lkbhe6ep",
+    "eventName": "10 Years of JSLovers",
+    "eventDescription": "JSLovers Turns 10",
+    "eventDate": "2025-04-05",
+    "eventTime": "09:30",
+    "eventVenue": "FORD GTBC, Sholinganallur, Chennai",
+    "eventLink": "https://lu.ma/jslc",
     "location": "Chennai",
     "communityName": "JSLovers",
     "communityLogo": "https://i.ibb.co/89fw9p0/1718639979394.jpg"


### PR DESCRIPTION
We’re thrilled to announce that the JSLovers Chennai Community Event is on April 05, 2025.