### PR TITLE
refactor: Updated @phosphor-icons/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "lint": "next lint && eslint . --max-warnings 0"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.7",
     "framer-motion": "^12.4.10",
     "next": "15.1.4",
     "next-umami": "^1.0.0",
-    "phosphor-react": "^1.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rss": "^1.2.2"

--- a/src/components/no-events-card.tsx
+++ b/src/components/no-events-card.tsx
@@ -1,4 +1,4 @@
-import { CalendarX } from 'phosphor-react';
+import { CalendarX } from '@phosphor-icons/react';
 
 export default function EmptyEventCard({
   message = 'No events scheduled for this period'

--- a/src/components/pages/home/events.tsx
+++ b/src/components/pages/home/events.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useRef, useState } from 'react';
 import events from '../../../data/events.json';
-import { MapPin } from 'phosphor-react';
+import { MapPin } from '@phosphor-icons/react';
 import EmptyEventCard from '../../no-events-card';
 import Image from 'next/image';
 import AddToCalendar from '@/components/AddToCalendar';


### PR DESCRIPTION
### Description  
This PR replaces the deprecated `phosphor-react` package with the latest `@phosphor-icons/react` for better performance, compatibility, and future updates.

### Changes Made  
- Removed `phosphor-react` package.  
- Installed `@phosphor-icons/react`.  
- Updated all icon imports to use `@phosphor-icons/react`.  
- Verified UI to ensure all icons render correctly.

### Why is this needed?  
✅ **Deprecated Package:** `phosphor-react` is no longer maintained.  
✅ **Improved Performance:** Better optimization and tree-shaking.  
✅ **Latest Icons & Updates:** Future enhancements will only be in `@phosphor-icons/react`.  
✅ **Better TypeScript Support:** Improved type definitions.

### Screenshots (if applicable)  
![image](https://github.com/user-attachments/assets/d0515967-31b4-42a9-9761-0f58743bd926)

### Related Issues  
Closes #187 
