### PR TITLE
feat: update FOSS meetup Chennai details for April 2025

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -45,11 +45,11 @@
   },
   {
     "eventName": "FOSS meetup Chennai",
-    "eventDescription": "March meetup of the FOSS United Chennai community!",
-    "eventDate": "2025-03-22",
+    "eventDescription": "April meetup of the FOSS United Chennai community!",
+    "eventDate": "2025-04-26",
     "eventTime": "14:00",
-    "eventVenue": "Tiger Analytics, RMZ Millenia Business Park 2",
-    "eventLink": "https://fossunited.org/c/chennai/2025/march",
+    "eventVenue": "Full Creative, Tharamani",
+    "eventLink": "https://fossunited.org/c/chennai/2025/april",
     "location": "Chennai",
     "communityName": "FOSS United Chennai",
     "communityLogo": "https://i.ibb.co/F45XJbvR/FOSS-United-Chennai.png"


### PR DESCRIPTION
## 📌 Pull Request: Add FOSS United Chennai Events

### ✅ Description

This PR adds upcoming and past **FOSS United Chennai** events to the project's event listings. FOSS United Chennai is an active city chapter focused on promoting Free and Open Source Software in the local community.

### 🗓️ Events Added

1. **FOSS Meetup Chennai - April 2025**  
   📅 Date: April 26, 2025  
   📍 Venue: Full Creative, Chennai  
  



