### PR TITLE
fix(events): update venue for FOSS United Chennai May meetup

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -104,7 +104,7 @@
     "eventDescription": "May meetup of the FOSS United Chennai community!",
     "eventDate": "2025-05-24",
     "eventTime": "10:00",
-    "eventVenue": "TBD",
+    "eventVenue": "Freshworks, Chennai",
     "eventLink": "https://fossunited.org/c/chennai/2025/may-fsf-40",
     "location": "Chennai",
     "communityName": "FOSS United Chennai",


### PR DESCRIPTION
I Have updated the FSF 40 Event Venue 

![Screenshot 2025-05-16 at 12 45 26 AM](https://github.com/user-attachments/assets/641689c5-3a0f-4d07-9fd4-b20fd064cad5)
