### PR TITLE
feat: add cleanup script and workflow for removing past events

### DIFF
--- a/.github/scripts/cleanup-events.js
+++ b/.github/scripts/cleanup-events.js
@@ -1,0 +1,43 @@
+/**
+ * Script to clean up past events from events.json
+ * This script removes events with dates earlier than the current date
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// Path to events.json file
+const eventsFilePath = path.join(process.cwd(), 'src', 'data', 'events.json');
+
+// Read the events file
+try {
+  const eventsData = JSON.parse(fs.readFileSync(eventsFilePath, 'utf8'));
+
+  // Get today's date and reset to midnight for fair comparison
+  const today = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Kolkata' }));
+  today.setHours(0, 0, 0, 0);
+
+  console.log(`Starting cleanup: ${eventsData.length} total events`);
+
+  // Filter out past events
+  const currentEvents = eventsData.filter((event) => {
+    const eventDate = new Date(event.eventDate);
+    // Keep events with today's date or future dates
+    return eventDate >= today;
+  });
+
+  const removedCount = eventsData.length - currentEvents.length;
+  console.log(`Removed ${removedCount} past events. Remaining: ${currentEvents.length}`);
+
+  // Only write to file if events were actually removed
+  if (removedCount > 0) {
+    // Write the filtered data back to the file with proper formatting
+    fs.writeFileSync(eventsFilePath, JSON.stringify(currentEvents, null, 2));
+    console.log('File updated successfully');
+  } else {
+    console.log('No past events to remove');
+  }
+} catch (error) {
+  console.error('Error processing events file:', error);
+  process.exit(1);
+}

--- a/.github/workflows/cleanup-past-events.yml
+++ b/.github/workflows/cleanup-past-events.yml
@@ -1,0 +1,36 @@
+name: Cleanup Past Events
+
+on:
+  schedule:
+    - cron: '30 18 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup-events:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Run cleanup script
+        run: node .github/scripts/cleanup-events.js
+
+      - name: Commit and push if changed
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add src/data/events.json
+          git diff --quiet && git diff --staged --quiet || (git commit -m "ci: remove past events" && git push)


### PR DESCRIPTION
This pull request introduces a new automation workflow to clean up past events from `events.json`. It includes a script to filter out outdated events and a GitHub Actions workflow to run the script on a scheduled basis or manually. 

### Event Cleanup Automation:

* [`.github/scripts/cleanup-events.js`](diffhunk://#diff-42d39a1a76380c28a8f1bed96ec1ea1d7989098f433523a4432db442479c3d91R1-R43): Added a script to remove events with dates earlier than the current date from `events.json`. The script ensures only current and future events remain, updates the file if changes are made, and logs the cleanup process.

### GitHub Actions Workflow:

* [`.github/workflows/cleanup-past-events.yml`](diffhunk://#diff-030c18260ef179ebe58368c84e34243570c8a3eece801d381d878299cfc9efb4R1-R36): Added a workflow to run the cleanup script daily at 6:30 PM IST using a cron schedule. The workflow installs dependencies, executes the script, and commits changes if any events are removed.