### PR TITLE
feat: enhance JSON validation workflow to check modified files before commenting on linting results

### DIFF
--- a/.github/workflows/json-validation.yml
+++ b/.github/workflows/json-validation.yml
@@ -52,8 +52,29 @@ jobs:
             echo "communities_lint_failed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check Modified Files
+        id: check-modified-files
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const eventsModified = files.some(file => file.filename === 'src/data/events.json');
+            const communitiesModified = files.some(file => file.filename === 'src/data/communities.json');
+
+            console.log(`Events modified: ${eventsModified}`);
+            console.log(`Communities modified: ${communitiesModified}`);
+
+            core.setOutput('events_modified', eventsModified.toString());
+            core.setOutput('communities_modified', communitiesModified.toString());
+
       - name: Comment on PR for Events Linting Failure
-        if: steps.lint-events.outputs.events_lint_failed == 'true'
+        if: steps.lint-events.outputs.events_lint_failed == 'true' && steps.check-modified-files.outputs.events_modified == 'true'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +89,7 @@ jobs:
             });
 
       - name: Comment on PR for Events Linting Success
-        if: steps.lint-events.outputs.events_lint_failed == 'false'
+        if: steps.lint-events.outputs.events_lint_failed == 'false' && steps.check-modified-files.outputs.events_modified == 'true'
         uses: actions/github-script@v6
         with:
           script: |
@@ -80,7 +101,7 @@ jobs:
             });
 
       - name: Comment on PR for Communities Linting Failure
-        if: steps.lint-communities.outputs.communities_lint_failed == 'true'
+        if: steps.lint-communities.outputs.communities_lint_failed == 'true' && steps.check-modified-files.outputs.communities_modified == 'true'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,7 +116,7 @@ jobs:
             });
 
       - name: Comment on PR for Communities Linting Success
-        if: steps.lint-communities.outputs.communities_lint_failed == 'false'
+        if: steps.lint-communities.outputs.communities_lint_failed == 'false' && steps.check-modified-files.outputs.communities_modified == 'true'
         uses: actions/github-script@v6
         with:
           script: |
@@ -113,14 +134,23 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            let summaryMessage = '🎉 **JSON Checks Passed**\n\n';
+
+            if (steps.check-modified-files.outputs.events_modified == 'true') {
+              summaryMessage += '- ✅ Events JSON Linting: Passed\n';
+            }
+
+            if (steps.check-modified-files.outputs.communities_modified == 'true') {
+              summaryMessage += '- ✅ Communities JSON Linting: Passed\n';
+            }
+
+            summaryMessage += '\nYour changes are ready to be merged!';
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🎉 **All JSON Checks Passed**\n\n' +
-                    '- ✅ Events JSON Linting: Passed\n' +
-                    '- ✅ Communities JSON Linting: Passed\n\n' +
-                    'Your changes are ready to be merged!'
+              body: summaryMessage
             });
 
             await github.rest.pulls.createReview({


### PR DESCRIPTION
This pull request updates the `.github/workflows/json-validation.yml` file to improve conditional logic and dynamic messaging for JSON linting checks. The changes ensure that PR comments are only posted when relevant files (`events.json` or `communities.json`) are modified, and enhance the success message with conditional summaries based on the modified files.

### Conditional Logic Enhancements:
* Added a new step `Check Modified Files` to detect changes to `src/data/events.json` and `src/data/communities.json`. Outputs `events_modified` and `communities_modified` indicate whether these files were modified.
* Updated conditions for posting PR comments on linting failures and successes to check both linting results and whether the respective files were modified. [[1]](diffhunk://#diff-5e90cb1eb5534e31ccc72f05d10261dc3e6c8f6aca4ef0b85b5a595baa87c6d0L71-R92) [[2]](diffhunk://#diff-5e90cb1eb5534e31ccc72f05d10261dc3e6c8f6aca4ef0b85b5a595baa87c6d0L83-R104) [[3]](diffhunk://#diff-5e90cb1eb5534e31ccc72f05d10261dc3e6c8f6aca4ef0b85b5a595baa87c6d0L98-R119)

### Dynamic Messaging Improvements:
* Modified the success message to dynamically include summaries for `events.json` and `communities.json` linting results based on file modifications.