### PR TITLE
feat: add Cloud Community Days 2025 Chennai on July 12th

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -31,5 +31,16 @@
     "location": "Coimbatore",
     "communityName": "FOSS United Coimbatore and FOSS-CIT",
     "communityLogo": "https://i.ibb.co/m5900Dn2/Logo-FOSS-United-CBE.jpg"
+  },
+  {
+    "eventName": "Cloud Community Days 2025 Chennai",
+    "eventDescription": "Flagship full-day event for developers, IT pros & cloud enthusiasts! Dive into Google Cloud & general cloud tech. Expect expert keynotes, technical sessions & hands-on workshops covering AI, ML, & Cloud Infra. Grow, learn & connect. Don't miss it!",
+    "eventDate": "2025-07-12",
+    "eventTime": "19:00",
+    "eventVenue": "Ford Global Technology & Business Center, W67C+98H, Elcot Sez, Sholinganallur, Tamil Nadu, Chennai, 600119",
+    "eventLink": "https://gdg.community.dev/events/details/google-gdg-cloud-chennai-presents-cloud-community-days-2025-chennai/",
+    "location": "Chennai",
+    "communityName": "GDG Cloud Chennai",
+    "communityLogo": "https://i.ibb.co/XZRVypNb/gdg-cloud-chennai-logo.jpg"
   }
 ]


### PR DESCRIPTION
Cloud Community Days 2025 Chennai is our flagship full-day event for developers, IT pros & cloud enthusiasts! Dive into Google Cloud & general cloud tech. Expect expert keynotes, technical sessions & hands-on workshops covering AI, ML, & Cloud Infra. Grow, learn & connect. Don't miss it!