### PR TITLE
fix: remove unwanted top margin from map pin icon

### DIFF
--- a/src/components/pages/Archive/archive.tsx
+++ b/src/components/pages/Archive/archive.tsx
@@ -235,7 +235,7 @@ const Archive = () => {
               </div>
               <div className='mt-auto flex flex-grow flex-col justify-end'>
                 <span className='mt-4 flex items-start gap-1 text-xs'>
-                  <MapPin size={16} className='mt-0.5 min-w-[16px]' />{' '}
+                  <MapPin size={16} className='min-w-[16px]' />{' '}
                   <span className='break-words'>{validateAndFormatVenue(venue)}</span>{' '}
                 </span>
               </div>

--- a/src/components/pages/home/events.tsx
+++ b/src/components/pages/home/events.tsx
@@ -239,7 +239,7 @@ const Events = () => {
               </div>
               <div className='mt-auto flex flex-grow flex-col justify-end'>
                 <span className='mt-4 flex items-start gap-1 text-xs'>
-                  <MapPin size={16} className='mt-0.5 min-w-[16px]' />{' '}
+                  <MapPin size={16} className='min-w-[16px]' />{' '}
                   <span className='break-words'>{validateAndFormatVenue(venue)}</span>{' '}
                 </span>
               </div>


### PR DESCRIPTION
This PR fixes a small UI issue where the map pin icon had an unwanted top margin, which affected vertical alignment with surrounding text. I’ve removed the extra margin to make the icon visually aligned and consistent.
<img width="1333" height="2000" alt="Fix Map-pin icon margin" src="https://github.com/user-attachments/assets/a67ffbd6-c80e-4132-9b8f-f9432c50d1bd" />
