### PR TITLE
feat: fetch events from GitHub with fallback to local data in RSS feed

### DIFF
--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -62,6 +62,10 @@ const fetchEvents = async (): Promise<Event[]> => {
     }
 
     const events = await response.json();
+    if (!isValidEventArray(events)) {
+      console.warn('Fetched events data is malformed, using local events');
+      return localEvents;
+    }
     return events;
   } catch (error) {
     console.error('Error fetching events from GitHub:', error);


### PR DESCRIPTION
feat(rss): enhance RSS feed with dynamic GitHub data fetching

- Add support for fetching events from GitHub repository
- Implement fallback to local events.json when GitHub fetch fails
- Add caching (5 minutes) to optimize performance and reduce API calls
- Include proper error handling and logging for GitHub fetch failures
- Maintain backward compatibility with local events as fallback
- Update function signatures and improve TypeScript typing

This ensures the RSS feed always serves the most up-to-date events
without requiring manual deployments while maintaining reliability.