### PR TITLE
feat: add START THE UP - Student's Community

### DIFF
--- a/src/data/communities.json
+++ b/src/data/communities.json
@@ -441,5 +441,14 @@
     "description": "ILUGC was started on 1997 and it is an one of the oldest Linux Users Group in India. We are a heterogeneous group of computer users from the South Indian city of Chennai (a.k.a Madras), united in our use of Free/Libre/Open Source Software and support of Software Freedom in general and GNU/Linux in particular",
     "location": "Chennai",
     "website": "https://ilugc.in/"
+  },
+  {
+    "name": "Start The Up",
+    "logo": "https://ibb.co/bgrhwVh5",
+    "description": "We are a student-driven startup community, empowering college students to explore entrepreneurship, build digital projects, and connect with like-minded innovators. We organize events, workshops, and mentorship sessions to help students kickstart their entrepreneurial journey and gain hands-on experience in tech, business, and startup.",
+    "location": "Chennai",
+    "website": "https://www.starttheup.vizhva.com",
+    "linkedin": "https://www.linkedin.com/company/start-the-up/",
+    "instagram": "https://www.instagram.com/start_theup"
   }
 ]


### PR DESCRIPTION
Added Start The Up, a student-driven startup community that empowers college students to explore entrepreneurship, build digital projects, and connect with like-minded innovators.