### PR TITLE
from-dev-to-ops Community Apri 11 event

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -474,6 +474,20 @@
     "communityLogo": "https://res.cloudinary.com/dfhtr1rwo/image/upload/v1762066985/opensearch_logo_hg3k8s.png"
   },
   {
+    "eventName": "From-Dev-to-Ops | Devops Community Meetup Apr 11",
+    "eventDescription": "From-Dev-to-Ops is a community of devops, SRE and Platform Engineers who share raw, behind-the-scenes war room experiences — the outages, the quick fixes, the lessons learned, and the systems that broke in a fun, honest, and simple way.",
+    "eventDate": "2026-04-11",
+    "eventTime": "09:30",
+    "eventVenue": "Sagent, DLF Porur, 1/124, Mount Poonamallee Rd, Manapakkam, Chennai, Tamil Nadu 600089",
+    "eventLink": "https://luma.com/rb1bqtax",
+    "location": "Chennai",
+    "communityName": "From-Dev-to-Ops",
+    "communityLogo": "https://i.ibb.co/KZTKzgt/from-dev-to-ops-logo-900-x-900-px.png"
+    "alert": {
+      "message": "Limited seats available. Register early.",
+      "type": "general"
+  },  
+  {
     "eventName": "CodeSapiens × She Builds Chennai - Women in Tech March Meetup",
     "eventDescription": "CodeSapiens × She Builds Chennai March Meetup celebrating Women in Tech. Connect, learn, and grow with women developers through real ideas, skills, and collaboration.",
     "eventDate": "2026-03-15",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -486,6 +486,7 @@
     "alert": {
       "message": "Limited seats available. Register early.",
       "type": "general"
+    }  
   },  
   {
     "eventName": "CodeSapiens × She Builds Chennai - Women in Tech March Meetup",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -482,7 +482,7 @@
     "eventLink": "https://luma.com/rb1bqtax",
     "location": "Chennai",
     "communityName": "From-Dev-to-Ops",
-    "communityLogo": "https://i.ibb.co/KZTKzgt/from-dev-to-ops-logo-900-x-900-px.png"
+    "communityLogo": "https://i.ibb.co/KZTKzgt/from-dev-to-ops-logo-900-x-900-px.png",
     "alert": {
       "message": "Limited seats available. Register early.",
       "type": "general"


### PR DESCRIPTION
from-dev-to-ops Community Apri 11 event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "From-Dev-to-Ops | Devops Community Meetup Apr 11" event (April 11, 2026, 09:30) to event listings with venue/address, location, community name and logo, event link, and description. Includes an alert banner: "Limited seats available. Register early." The new event is available in the app's events view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->