### PR TITLE
feat: add build2learn meetup details for april event

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -521,5 +521,18 @@
       "message": "Register early and secure your spots soon! Built by her. Backed by boldness.",
       "type": "general"
     }
+  },
+    {
+    "eventName": "Build2Learn Meetup #35",
+    "eventDescription": "Welcome to build2learn - Where Innovation Meets Community",
+    "eventDate": "2026-04-11",
+    "eventTime": "09:30",
+    "eventEndDate": "2026-04-11",
+    "eventEndTime": "14:00",
+    "eventVenue": "Freshworks, GLOBAL INFOCITY PARK, Perungudi, Chennai",
+    "eventLink": "https://events.build2learn.in/",
+    "location": "Chennai",
+    "communityName": "Build2Learn",
+    "communityLogo": "https://i.ibb.co/CBsgh43/bxOxo5O.png"
   }
 ]


### PR DESCRIPTION
Hi Justin,
Added the details for Build2learn April event

pls check and merge the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Build2Learn Meetup #35" event scheduled for April 11, 2026, from 9:30 AM to 2:00 PM. Event includes complete venue information, registration link, and community details for attendees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->