### PR TITLE
feat: add Digital Dreamers Den (D3) Meetup #7 on 2026-05-09

### DIFF
--- a/src/data/communities.json
+++ b/src/data/communities.json
@@ -159,7 +159,7 @@
   },
   {
     "name": "Digital Dreamers Den (D3)",
-    "logo": "https://i.ibb.co/Lh1nbgjy/D3-Community-Official-logo.png",
+    "logo": "https://podu.pics/3bjvlRL2v1",
     "description": "Digital Dreamers Den (D3) is a vibrant tech community that brings together AI Full-Stack Developers to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
     "location": "Chennai",
     "twitter": "https://d3community.in/x",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -23,12 +23,12 @@
     "paid": true
   },
   {
-    "eventName": "Digital Dreamers Den (D3) Meetup #6",
+    "eventName": "Digital Dreamers Den (D3) Anniversary - Meetup #7",
     "eventDescription": "Digital Dreamers Den (D3) is a vibrant tech community that brings together AI Full-Stack Developers to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
-    "eventDate": "2026-03-28",
+    "eventDate": "2026-05-09",
     "eventTime": "14:00",
     "eventVenue": "Tekclan Software Solutions PVT. LTD., 4th Floor, PHASE-2, TICEL Biopark Rd, Tharamani, Chennai, Tamil Nadu 600113, India",
-    "eventLink": "https://luma.com/qsfq2226",
+    "eventLink": "https://luma.com/5jkpoleg",
     "location": "Chennai",
     "communityName": "Digital Dreamers Den (D3)",
     "communityLogo": "https://podu.pics/7cC3FwEqRJ"

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -31,7 +31,7 @@
     "eventLink": "https://luma.com/5jkpoleg",
     "location": "Chennai",
     "communityName": "Digital Dreamers Den (D3)",
-    "communityLogo": "https://podu.pics/7cC3FwEqRJ"
+    "communityLogo": "https://podu.pics/K3Hbv3raG1"
   },
   {
     "eventName": "From Dev to Ops | Devops Community Meetup Nov 15",
@@ -486,8 +486,8 @@
     "alert": {
       "message": "Limited seats available. Register early.",
       "type": "general"
-    }  
-  },  
+    }
+  },
   {
     "eventName": "CodeSapiens × She Builds Chennai - Women in Tech March Meetup",
     "eventDescription": "CodeSapiens × She Builds Chennai March Meetup celebrating Women in Tech. Connect, learn, and grow with women developers through real ideas, skills, and collaboration.",
@@ -537,7 +537,7 @@
       "type": "general"
     }
   },
-    {
+  {
     "eventName": "Build2Learn Meetup #35",
     "eventDescription": "Welcome to build2learn - Where Innovation Meets Community",
     "eventDate": "2026-04-11",


### PR DESCRIPTION
added D3 Meetup # 7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed "Digital Dreamers Den (D3) Meetup #6" to "Digital Dreamers Den (D3) Anniversary - Meetup #7".
  * Updated event date to 2026-05-09 and refreshed the event registration link.
  * Replaced the community logo for Digital Dreamers Den with a new image.
  * Cleaned up event listing formatting to ensure consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->