### PR TITLE
chore: updated event time Digital Dreamers Den (D3) Meetup #7 on 2026…

### DIFF
--- a/src/data/communities.json
+++ b/src/data/communities.json
@@ -160,13 +160,14 @@
   {
     "name": "Digital Dreamers Den (D3)",
     "logo": "https://podu.pics/3bjvlRL2v1",
-    "description": "Digital Dreamers Den (D3) is a vibrant tech community that brings together AI Full-Stack Developers to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
+    "description": "A vibrant tech community bringing AI and Full-Stack Engineers together to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
     "location": "Chennai",
-    "twitter": "https://d3community.in/x",
-    "website": "https://d3community.in",
-    "instagram": "https://d3community.in/instagram",
-    "linkedin": "https://d3community.in/linkedin",
-    "youtube": "https://d3community.in/youtube"
+    "twitter": "https://digitaldreamersden.in/x",
+    "website": "https://digitaldreamersden.in/",
+    "instagram": "https://digitaldreamersden.in/instagram",
+    "linkedin": "https://digitaldreamersden.in/linkedin",
+    "youtube": "https://digitaldreamersden.in/youtube",
+    "github": "https://digitaldreamersden.in/github"
   },
   {
     "name": "MongoDB User Group Chennai",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -26,12 +26,16 @@
     "eventName": "Digital Dreamers Den (D3) Anniversary - Meetup #7",
     "eventDescription": "Digital Dreamers Den (D3) is a vibrant tech community that brings together AI Full-Stack Developers to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
     "eventDate": "2026-05-09",
-    "eventTime": "14:00",
+    "eventTime": "13:30",
     "eventVenue": "Tekclan Software Solutions PVT. LTD., 4th Floor, PHASE-2, TICEL Biopark Rd, Tharamani, Chennai, Tamil Nadu 600113, India",
     "eventLink": "https://luma.com/5jkpoleg",
     "location": "Chennai",
     "communityName": "Digital Dreamers Den (D3)",
-    "communityLogo": "https://podu.pics/K3Hbv3raG1"
+    "communityLogo": "https://podu.pics/K3Hbv3raG1",
+    "alert": {
+      "message": "Event timing is changed from 2:00 PM to 1:30 PM",
+      "type": "general"
+    }
   },
   {
     "eventName": "From Dev to Ops | Devops Community Meetup Nov 15",


### PR DESCRIPTION
…-05-09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected start time for Digital Dreamers Den (D3) Anniversary - Meetup #7 (now 13:30).

* **New Features**
  * Added an alert notification to inform users about the event timing update.

* **Content Updates**
  * Updated Digital Dreamers Den (D3) description and refreshed social/website links; added a GitHub link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->