### PR TITLE
from-dev-to-ops May 16 event

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -75,5 +75,16 @@
     "location": "Chennai",
     "communityName": "Namma Flutter",
     "communityLogo": "https://avatars.githubusercontent.com/u/176333249"
+  },
+  {
+    "eventName": "From Dev to Ops | Devops Community Meetup May 16",
+    "eventDescription": "From Dev to Ops is a community of devops practitioners who share raw, behind-the-scenes war room experiences — the outages, the quick fixes, the lessons learned, and the systems that broke in a fun, honest, and simple way.",
+    "eventDate": "2026-05-16",
+    "eventTime": "09:30",
+    "eventVenue": "MCC MRF Innovation Park, MCC, East Tambaram, Chennai, Tamil Nadu 600059",
+    "eventLink": "https://luma.com/vhuicj7f",
+    "location": "Chennai",
+    "communityName": "From Dev to Ops",
+    "communityLogo": "https://i.ibb.co/KZTKzgt/from-dev-to-ops-logo-900-x-900-px.png"
   }
 ]


### PR DESCRIPTION
from-dev-to-ops May 16 event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "From Dev to Ops | DevOps Community Meetup" event for May 16, 2026 at 09:30 with complete venue details, event link, and community branding information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSUChennai/Communities/pull/599)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->