### PR TITLE
feat: added May 2026 - FOSS United Chennai Meetup on May 23rd

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -597,5 +597,16 @@
     "location": "Chennai",
     "communityName": "Shebuilds Chennai",
     "communityLogo": "https://podu.pics/gqDU4H07VM"
+  },
+  {
+    "eventName": "May FOSS Meetup",
+    "eventDescription": "FOSS United Chennai Monthly Meetup - May 2026",
+    "eventDate": "2026-05-23",
+    "eventTime": "09:00",
+    "eventVenue": "YuniQ, 4th Floor, TICEL BIOPARK, 5, CSIR Rd, Phase II, Tharamani, Chennai, Tamil Nadu 600113",
+    "eventLink": "https://fossunited.org/c/chennai/may-26",
+    "location": "Chennai",
+    "communityName": "FOSS United Chennai",
+    "communityLogo": "https://fossunited.org/files/Foss%20United%20Logo%20Black.svg"
   }
 ]


### PR DESCRIPTION
This pr is to update the Foss United chennai monthly meetup happening on 23rd may-2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a formatting error in the events data file.
* **New Features**
  * Added a new event: May FOSS Meetup scheduled for May 23, 2026, with complete venue, location, community, and logo information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSUChennai/Communities/pull/602)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->