### PR TITLE
feat: Add TOSSConf 2026 event details

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -636,7 +636,7 @@
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation.",
     "eventDate": "2026-07-18",
     "eventTime": "09:00",
-+   "eventEndDate": "2026-07-19",
+    "eventEndDate": "2026-07-19",
     "eventEndTime": "17:00",
     "eventVenue": "Off, Old Mahabalipuram Road, Kamaraj Nagar, Semmancheri, Chennai, Tamil Nadu 600119",
     "eventLink": "https://tossconf26.kaniyam.com/",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -630,5 +630,16 @@
     "location": "Chennai",
     "communityName": "JSLovers Chennai",
     "communityLogo": "https://i.ibb.co/My6JNtNx/jslovers-Logo.png"
+  },
+  {
+    "eventName": "TOSSConf 2026 - தமிழ் கட்டற்ற மென்பொருள் மாநாடு",
+    "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation.",
+    "eventDate": "2026-07-18, 2026-07-19",
+    "eventTime": "09:00",
+    "eventVenue": "Off, Old Mahabalipuram Road, Kamaraj Nagar, Semmancheri, Chennai, Tamil Nadu 600119",
+    "eventLink": "https://tossconf26.kaniyam.com/",
+    "location": "Chennai",
+    "communityName": "Kaniyam Foundation",
+    "communityLogo": "https://podu.pics/44lf_1y7mQ"
   }
 ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -634,8 +634,10 @@
   {
     "eventName": "TOSSConf 2026 - தமிழ் கட்டற்ற மென்பொருள் மாநாடு",
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation.",
-    "eventDate": "2026-07-18, 2026-07-19",
+    "eventDate": "2026-07-18",
     "eventTime": "09:00",
++   "eventEndDate": "2026-07-19",
+    "eventEndTime": "17:00",
     "eventVenue": "Off, Old Mahabalipuram Road, Kamaraj Nagar, Semmancheri, Chennai, Tamil Nadu 600119",
     "eventLink": "https://tossconf26.kaniyam.com/",
     "location": "Chennai",


### PR DESCRIPTION
Added details for TOSSConf 2026 event including name, description, date, time, venue, link, and community information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TOSSConf 2026 (தமிழ் கட்டற்ற மென்பொருள் மாநாடு) event for July 18–19, 2026 — includes description, times, venue and location details, registration link, community name, and event logo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->