### PR TITLE
feat: add Opensearch event on 2026-06-20

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -642,6 +642,7 @@
     "communityName": "OpenSearch User Group Chennai",
     "communityLogo": "https://res.cloudinary.com/dfhtr1rwo/image/upload/v1762066985/opensearch_logo_hg3k8s.png"
   },
+  {
     "eventName": "தமிழ் கட்டற்ற மென்பொருள் மாநாடு 2026 | TOSSConf 2026",
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation. ",
     "eventDate": "2026-06-09",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -630,5 +630,16 @@
     "location": "Chennai",
     "communityName": "JSLovers Chennai",
     "communityLogo": "https://i.ibb.co/My6JNtNx/jslovers-Logo.png"
+  },
+  {
+    "eventName": "Search Reimagined: AI, Speed & Reliability",
+    "eventDescription": "Explore the future of search with AI-powered capabilities, faster results, and reliable systems built for modern applications.",
+    "eventDate": "2026-06-20",
+    "eventTime": "10:00",
+    "eventVenue": "Genesys Cloud Services India Private Limited | Plot No.40, 7th Floor, Global Infocity Park, Block C, MGR, Anna Nedunchalai, Perungudi, Chennai, Tamil Nadu 600096",
+    "eventLink": "https://www.meetup.com/opensearch-project-chennai/events/315050068",
+    "location": "Chennai",
+    "communityName": "OpenSearch User Group Chennai",
+    "communityLogo": "https://res.cloudinary.com/dfhtr1rwo/image/upload/v1762066985/opensearch_logo_hg3k8s.png"
   }
 ]


### PR DESCRIPTION
This pull request adds a new event to the events data for Chennai. The update introduces details about an upcoming event focused on AI-powered search, including its date, venue, and organizing community.

**Event additions:**

* Added a new event, "Search Reimagined: AI, Speed & Reliability," scheduled for June 20, 2026, organized by the OpenSearch User Group Chennai, with full event details including description, time, venue, and community logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new event: "Search Reimagined: AI, Speed & Reliability" by OpenSearch User Group Chennai, including date, time, venue, registration link, location, and community logo.
  * Events list now surfaces the new meetup prominently so users can discover and register easily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->