### PR TITLE
Update on Date in TossConf

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -630,5 +630,16 @@
     "location": "Chennai",
     "communityName": "JSLovers Chennai",
     "communityLogo": "https://i.ibb.co/My6JNtNx/jslovers-Logo.png"
+  },
+  {
+    "eventName": "தமிழ் கட்டற்ற மென்பொருள் மாநாடு 2026 | TOSSConf 2026",
+    "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation. ",
+    "eventDate": "2026-06-09",
+    "eventTime": "09:00",
+    "eventVenue": "St. Joseph's Institute of TechnologyOld Mamallapuram Road (OMR)Kamaraj Nagar, SemmancheriChennai, Tamil Nadu 600119",
+    "eventLink": "https://tossconf26.kaniyam.com",
+    "location": "Chennai",
+    "communityName": "TossConf 2026",
+    "communityLogo": "https://tossconf26.kaniyam.com/images/hero_bg1.png"
   }
 ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -636,7 +636,7 @@
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation. ",
     "eventDate": "2026-06-09",
     "eventTime": "09:00",
-    "eventVenue": "St. Joseph's Institute of TechnologyOld Mamallapuram Road (OMR)Kamaraj Nagar, SemmancheriChennai, Tamil Nadu 600119",
+    "eventVenue": "St. Joseph's Institute of Technology, Old Mamallapuram Road (OMR)Kamaraj Nagar, SemmancheriChennai, Tamil Nadu 600119",
     "eventLink": "https://tossconf26.kaniyam.com",
     "location": "Chennai",
     "communityName": "TossConf 2026",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -634,12 +634,12 @@
   {
     "eventName": "தமிழ் கட்டற்ற மென்பொருள் மாநாடு 2026 | TOSSConf 2026",
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation. ",
-    "eventDate": "2026-06-09",
+    "eventDate": "2026-07-09",
     "eventTime": "09:00",
     "eventVenue": "St. Joseph's Institute of Technology, Old Mamallapuram Road (OMR)Kamaraj Nagar, SemmancheriChennai, Tamil Nadu 600119",
     "eventLink": "https://tossconf26.kaniyam.com",
     "location": "Chennai",
     "communityName": "TossConf 2026",
-    "communityLogo": "https://tossconf26.kaniyam.com/images/hero_bg1.png"
+    "communityLogo": "https://i.ibb.co/350BQ0mG/tossconf.png"
   }
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TOSSConf 2026 event date to July 9, 2026 and adjusted event listing accordingly (time, venue remain).
  * Replaced the community logo for the event with an updated image (https://i.ibb.co/350BQ0mG/tossconf.png).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->