### PR TITLE
feat: add Into the Void 2.0 on Jul 18

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -734,5 +734,20 @@
     "location": "Chennai",
     "communityName": "Tech4Good Community",
     "communityLogo": "https://podu.pics/LFmvh1XKaL"
+  },
+  {
+    "eventName": "Into the Void 2.0",
+    "eventDescription": "A national-level Capture the Flag (CTF) competition with online prelims and offline grand finals, challenging participants across diverse cybersecurity domains.",
+    "eventDate": "2026-07-18",
+    "eventTime": "09:00",
+    "eventVenue": "Chennai Institute of Technology, Sarathy Nagar, Kundrathur, Chennai, Tamil Nadu 600069",
+    "eventLink": "https://void.exploitx.org",
+    "location": "Chennai",
+    "communityName": "ExploitX",
+    "communityLogo": "https://podu.pics/W5QuJhfjne",
+    "alert": {
+      "message": "Prelims: 18 July 2026 | 12 Hours | Online &  Finals: 30-31 July 2026 | 24 Hours | Offline at CIT Chennai",
+      "type": "general"
+    }
   }
 ]


### PR DESCRIPTION
Into the Void 2.0, a national-level cybersecurity Capture the Flag (CTF) competition organized by ExploitX. The event consists of a 12-hour online preliminary round followed by a 24-hour offline grand finale at Chennai Institute of Technology for the top-performing teams.

This event was added to expand the collection of cybersecurity opportunities and provide students, beginners, and security enthusiasts with access to a high-quality, hands-on CTF experience. It helps the community discover competitive cybersecurity events, improve practical skills, and engage with a growing cybersecurity ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new event listing, **“Into the Void 2.0,”** including complete details such as date/time, venue, location, registration link, and community branding.
  * Added an alert message covering the online prelims (18 July 2026) and offline grand finals (30–31 July 2026) with venue information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->