### PR TITLE
feat: added Augest 2026 - ElasticSearch Chennai Meetup on Augest 8th

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -734,5 +734,16 @@
     "location": "Chennai",
     "communityName": "Tech4Good Community",
     "communityLogo": "https://podu.pics/LFmvh1XKaL"
+  },
+  {
+    "eventName": "Hands-On: Build Agentic Workflows and Searchable Apps with Elasticsearch, Jina, and Agent-to-Agent Communication",
+    "eventDescription": "In this hands-on, code-along workshop, you'll combine A2A (Agent-to-Agent) protocol, Jina Embeddings, and Elastic Agent Builder to create agentic workflows that run on top of Elasticsearch. Step by step, You'll turn your data into searchable vectors, wire agents together, and ship a working application by the end of the session.",
+    "eventDate": "2026-07-08",
+    "eventTime": "10:00",
+    "eventVenue": "SQ1 Security Technology Private Limited: 2nd Floor Block B, International Tech Park, Futura Tech Park, Rajiv Gandhi Salai, OMR, Sholinganallur, Chennai, Tamil Nadu 600119",
+    "eventLink": "https://luma.com/you-x2s5",
+    "location": "Chennai",
+    "communityName": "Elastic Chennai User Group",
+    "communityLogo": "https://i.ibb.co/XkLjmzG5/Chennai-Badge-Template.png"
   }
 ]


### PR DESCRIPTION
I've added the event page for the "Building Agentic Search Applications" workshop. When you have a chance, could you kindly take a look and let me know if any changes are needed? I'd really appreciate your feedback.

Thanks again for your time!

Cheers
Cardoz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Chennai workshop event, “Hands-On: Build Agentic Workflows and Searchable Apps with Elasticsearch, Jina, and Agent-to-Agent Communication.”
  * The event is scheduled for July 8, 2026, at 10:00, with venue, location, registration link, and community details available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->