### PR TITLE
feat: updated TOSSConf date to July 23

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -656,7 +656,7 @@
   {
     "eventName": "தமிழ் கட்டற்ற மென்பொருள் மாநாடு 2026 | TOSSConf 2026",
     "eventDescription": "Join the largest gathering of Tamil Open Source developers, creators, and localization enthusiasts. Building privacy-first tools, translation frameworks, and computing freedom for the next generation. ",
-    "eventDate": "2026-07-09",
+    "eventDate": "2026-07-23",
     "eventTime": "09:00",
     "eventVenue": "St. Joseph's Institute of Technology, Old Mamallapuram Road (OMR)Kamaraj Nagar, SemmancheriChennai, Tamil Nadu 600119",
     "eventLink": "https://tossconf26.kaniyam.com",


### PR DESCRIPTION
TOSSConf date is updated to July 23,24,25 
Kindly update to reflect on tamilnadu.tech

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the date for தமிழ் கட்டற்ற மென்பொருள் மாநாடு 2026 | TOSSConf 2026 to July 23, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->