### PR TITLE
add : FOSS United Chennai X From Dev to Ops on Aug 01

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -748,7 +748,7 @@
     "alert": {
       "message": "Prelims: 18 July 2026 | 12 Hours | Online &  Finals: 30-31 July 2026 | 24 Hours | Offline at CIT Chennai",
       "type": "general"
-    },
+    }
   },
     {
     "eventName": "Hands-On: Build Agentic Workflows and Searchable Apps with Elasticsearch, Jina, and Agent-to-Agent Communication",
@@ -760,5 +760,16 @@
     "location": "Chennai",
     "communityName": "Elastic Chennai User Group",
     "communityLogo": "https://i.ibb.co/XkLjmzG5/Chennai-Badge-Template.png"
+  },
+    {
+    "eventName": "FOSS United Chennai X From Dev to Ops",
+    "eventDescription": "FOSS United Chennai Monthly meetup X From Dev to Ops - August 2026",
+    "eventDate": "2026-08-01",
+    "eventTime": "9:00",
+    "eventVenue": "Ideas2IT Technology Services Private Limited",
+    "eventLink": "https://fossunited.org/c/chennai/august-26",
+    "location": "Chennai",
+    "communityName": "FOSS United Chennai",
+    "communityLogo": "https://fossunited.org/files/Foss%20United%20Logo%20Black.svg"
   }
 ]


### PR DESCRIPTION
added FOSS United Chennai X From Dev to Ops on Aug 01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “FOSS United Chennai X From Dev to Ops” event, including its schedule, venue, registration link, and event details.
* **Content Updates**
  * Updated the event listing data to ensure the existing “Into the Void 2.0” entry displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->