### PR TITLE
fix: Removed Star History and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,6 @@ This platform supports web push notifications for event updates:
   <img src="https://contrib.rocks/image?repo=fossuchennai/communities" />
 </a>
 
-## ⭐ Star History
-
-Go put a star 😤
-
-[![Star History Chart](https://api.star-history.com/svg?repos=FOSSUChennai/Communities&type=Date)](https://www.star-history.com/#FOSSUChennai/Communities&Date)
-
 ## 📝 License
 
 This project is licensed under the terms of the GPL 3.0 license.


### PR DESCRIPTION
Star-history retrieves star data via the GitHub API. Since GitHub now restricts access to starred repository data to only the repository's admins and collaborators, star history is available exclusively for repositories you own or collaborate on, provided you have an access token with the necessary permissions. Consequently, I have removed the feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Star History section and promotional prompt from the README.
  * Streamlined the transition from the contributors section to the license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->