### PR TITLE
feat: add Google I/O Extended Chennai 2026

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -793,5 +793,16 @@
     "location": "Chennai",
     "communityName": "BrowserStack Software Testing and QA Meetup Group - Chennai",
     "communityLogo": "https://podu.pics/NWDcUQyZ9M"
+  },
+  {
+    "eventName": "Google I/O Extended Chennai 2026",
+    "eventDescription": "GDG Chennai and WTM Chennai bring Google I/O home! Join us for Google I/O Extended Chennai 2026 — a day of talks on Gemini 3.5, agentic AI, Android, and the biggest launches from I/O 2026, hosted in partnership with Ford.",
+    "eventDate": "2026-08-01",
+    "eventTime": "09:00",
+    "eventVenue": "Ford Global Technology & Business Center Sholinganallur, Chennai, TN 600119",
+    "eventLink": "https://gdg.community.dev/events/details/google-gdg-chennai-presents-google-io-extended-chennai-2026/",
+    "location": "Chennai",
+    "communityName": "Google Developer Group Chennai",
+    "communityLogo": "https://podu.pics/FacbnJ117W"
   }
 ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -799,6 +799,7 @@
     "eventDescription": "GDG Chennai and WTM Chennai bring Google I/O home! Join us for Google I/O Extended Chennai 2026 — a day of talks on Gemini 3.5, agentic AI, Android, and the biggest launches from I/O 2026, hosted in partnership with Ford.",
     "eventDate": "2026-08-01",
     "eventTime": "09:00",
+    "eventEndTime": "17:30",
     "eventVenue": "Ford Global Technology & Business Center Sholinganallur, Chennai, TN 600119",
     "eventLink": "https://gdg.community.dev/events/details/google-gdg-chennai-presents-google-io-extended-chennai-2026/",
     "location": "Chennai",


### PR DESCRIPTION
can anyone plz add this!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Google I/O Extended Chennai 2026** event to the events list, including description, **Aug 1, 2026 (09:00–17:30)**, venue, Chennai location, registration link, and community details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->