### PR TITLE
feat: add AI Careers Mixer - August 2

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1,5 +1,16 @@
 [
   {
+    "eventName": "AI Careers Mixer: Chennai Edition!",
+    "eventDescription": "AI Careers Mixer - August 2",
+    "eventDate": "2026-08-01",
+    "eventTime": "13:00",
+    "eventVenue": "Perungudi, Chennai",
+    "eventLink": "https://www.goavo.ai/events/forms/fillup?id=6a61d1d7a7d095fcd981f354&utm_source=referral&utm_medium=personal_invite&utm_campaign=community_referral&utm_code=25a27701d29e",
+    "location": "Chennai",
+    "communityName": "DevRelSquad",
+    "communityLogo": "https://www.devrelsquad.com/assets/Black_Logo-D3q49o8f.svg"
+  },
+  {
     "eventName": "ILUGC Monthly Meet - November 8",
     "eventDescription": "ILUGC Monthly Meet - November 8",
     "eventDate": "2025-11-08",


### PR DESCRIPTION
Added the AI Careers Mixer - August 2 event to the events list, including description, Aug 2, 2026 (13:00–15:00), venue, Chennai location, registration link, and community details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “AI Careers Mixer: Chennai Edition!” event, including its date, time, venue, registration link, hosting community, and branding details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->