### PR TITLE
feat: surface paid/free badge on event cards + fix in-place sort mutation

### DIFF
--- a/src/components/pages/home/events.tsx
+++ b/src/components/pages/home/events.tsx
@@ -5,24 +5,7 @@ import { MapPin, Warning } from '@phosphor-icons/react';
 import EmptyEventCard from '../../no-events-card';
 import Image from 'next/image';
 import AddToCalendar from '@/components/AddToCalendar';
-
-type Event = {
-  communityName: string;
-  communityLogo: string;
-  eventName: string;
-  eventDate: string;
-  eventEndDate?: string;
-  eventVenue: string;
-  eventTime: string;
-  eventEndTime?: string;
-  eventLink: string;
-  location: string;
-  alert?: {
-    message: string;
-    type?: 'postponed' | 'venue-change' | 'cancelled' | 'general';
-  };
-  paid?: boolean;
-};
+import type { Event } from '@/types/event';
 
 type EventCardProps = {
   communityName: string;

--- a/src/components/pages/home/events.tsx
+++ b/src/components/pages/home/events.tsx
@@ -21,6 +21,7 @@ type Event = {
     message: string;
     type?: 'postponed' | 'venue-change' | 'cancelled' | 'general';
   };
+  paid?: boolean;
 };
 
 type EventCardProps = {
@@ -39,6 +40,7 @@ type EventCardProps = {
     message: string;
     type?: 'postponed' | 'venue-change' | 'cancelled' | 'general';
   };
+  paid?: boolean;
 };
 
 const Events = () => {
@@ -79,7 +81,7 @@ const Events = () => {
   }, []);
 
   // sorts all events first rather than grouping into two types and then sorting
-  const sortedEvents = events.sort(
+  const sortedEvents = [...events].sort(
     (a, b) => new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime()
   );
 
@@ -131,7 +133,8 @@ const Events = () => {
     link,
     logo,
     isMonthly,
-    alert
+    alert,
+    paid
   }) => {
     const [mousePosition, setMousePosition] = React.useState<{
       x: number;
@@ -322,6 +325,15 @@ const Events = () => {
               <span className={`rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-800`}>
                 {formattedDate}
               </span>
+              {typeof paid === 'boolean' && (
+                <span
+                  className={`rounded px-2 py-0.5 text-xs ${
+                    paid ? 'bg-red-100 text-red-800' : 'bg-emerald-100 text-emerald-800'
+                  }`}
+                >
+                  {paid ? 'PAID' : 'FREE'}
+                </span>
+              )}
               <span className={`rounded bg-yellow-100 px-2 py-0.5 text-xs text-yellow-800`}>
                 {formattedTime}
               </span>
@@ -376,6 +388,7 @@ const Events = () => {
                 logo={event.communityLogo}
                 isMonthly={true}
                 alert={event.alert}
+                paid={event.paid}
               />
             ))
           ) : (
@@ -405,6 +418,7 @@ const Events = () => {
                 logo={event.communityLogo}
                 isMonthly={false}
                 alert={event.alert}
+                paid={event.paid}
               />
             ))
           ) : (

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -10,6 +10,7 @@ export interface Event {
   location: string;
   communityName: string;
   communityLogo: string;
+  paid?: boolean;
   alert?: {
     message: string;
     type?: 'postponed' | 'venue-change' | 'cancelled' | 'general';


### PR DESCRIPTION
Closes #670

## Changes

1. **`paid` field is now live** — added `paid?: boolean` to the `Event` type (`src/types/event.d.ts`) and render a **PAID / FREE** badge on event cards in `src/components/pages/home/events.tsx`. The badge only shows when the field is explicitly set (`paid: true` → red PAID, `paid: false` → green FREE), so existing events without the field are unaffected. DevFest 2025 Chennai (which already has `"paid": true`) now displays correctly.

2. **Fixed in-place sort mutation** — `src/components/pages/home/events.tsx` was calling `.sort()` directly on the `events` state array, which mutates React state during render. Changed to `[...events].sort(...)` so the original state array is never mutated.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `eslint` on changed files — clean
- `pnpm build` — succeeds
- prettier applied

## Checklist

- [x] Add `paid` to `Event` type
- [x] Render PAID/FREE badge in `EventCard`
- [x] Fix in-place sort mutation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event cards now display **PAID** or **FREE** badges when pricing information is available.
  * Monthly and upcoming event listings support optional paid-status information across event displays.

* **Bug Fixes**
  * Improved event sorting reliability without altering the underlying event data.
  * Event listings now consistently use shared event information, improving accuracy across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->