### PR TITLE
fix: use whitelisted podu.pics host for Build2Learn #37 logo (#679)

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -887,6 +887,6 @@
     "eventLink": "https://events.build2learn.in/",
     "location": "Perungudi, Chennai",
     "communityName": "Build2Learn",
-    "communityLogo": "https://www.podu.pics/ddT2CTFU_t"
-    }
+    "communityLogo": "https://podu.pics/ddT2CTFU_t"
+  }
 ]


### PR DESCRIPTION
## 🎯 Fixes #679 — Build2Learn #37 logo now shows in production

### The bug

The Build2Learn #37 event card's **community logo was silently missing in production**, exactly as reported in #679. The logo worked when the PR was developed locally, but once deployed the image just didn't render — and there was no visible error, just a broken card.

### Root cause

The `communityLogo` for Build2Learn #37 in `src/data/events.json` used the host:

```
https://www.podu.pics/ddT2CTFU_t      ← www. prefix
```

But `next.config.ts` whitelists only `podu.pics` (no `www.`) in `images.remotePatterns`. Next.js's `next/image` **refuses to fetch any image whose hostname isn't whitelisted** — so the `www.podu.pics` URL was blocked at the optimizer level and the logo never loaded. This matched the maintainer's hint in the issue comments: *"did you allow the domain in whitelist to fetch?"*

### The fix

Changed the logo URL to the already-whitelisted host, consistent with **all 40+ other podu.pics logos** in the repo:

```diff
- "communityLogo": "https://www.podu.pics/ddT2CTFU_t"
+ "communityLogo": "https://podu.pics/ddT2CTFU_t"
```

While touching this entry I also fixed the malformed closing-brace indentation (`    }` → `  }`) so the file passes Prettier.

### Verified live

Started the dev server and probed Next.js's image optimizer directly:
- ✅ **Fixed URL** `podu.pics/ddT2CTFU_t` → `HTTP 200` · `image/png` (299 bytes) — **logo renders**
- ❌ **Old URL** `www.podu.pics/ddT2CTFU_t` → `HTTP 400` · `"url" parameter is not allowed` — **exact prod failure**

Also confirmed: `podu.pics/ddT2CTFU_t` returns `200 image/png`, so the canonical host is safe to use.

### Checks

- `pnpm validate:events` ✅ (77 events, valid JSON)
- Prettier `--check` ✅
- lint-staged (eslint + prettier) ✅

---

**Note:** This PR and its analysis were **AI-generated by [opencode](https://opencode.ai)** on behalf of the contributor, as requested. The fix itself is deliberately minimal, zero-risk, and matches the repo's existing host-whitelist convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Build2Learn `#37` Meetup community logo link to ensure it loads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->