### PR TITLE
Fix communityLogo URL format in events.json

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -887,6 +887,6 @@
     "eventLink": "https://events.build2learn.in/",
     "location": "Perungudi, Chennai",
     "communityName": "Build2Learn",
-    "communityLogo": "https://www.podu.pics/ddT2CTFU_t"
+    "communityLogo": "https://podu.pics/ddT2CTFU_t"
     }
 ]


### PR DESCRIPTION
doing this to fix #679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Build2Learn `#37` Meetup community logo URL to ensure the image loads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->