### PR TITLE
feat(events): add Flutter South India 2026

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -900,5 +900,17 @@
     "location": "Chennai",
     "communityName": "CodeSapiens",
     "communityLogo": "https://podu.pics/5UwCWhjNXF"
+  },
+  {
+    "eventName": "Flutter South India 2026",
+    "eventDescription": "A community-led day for Flutter and Dart developers, happening 10 October 2026 in Chennai.",
+    "eventDate": "2026-10-10",
+    "eventTime": "09:00",
+    "eventVenue": "Venue TBA, Chennai",
+    "eventLink": "https://southindia.nammaflutter.com/",
+    "location": "Chennai",
+    "communityName": "Namma Flutter",
+    "communityLogo": "https://avatars.githubusercontent.com/u/176333249",
+    "paid": true
   }
 ]


### PR DESCRIPTION
## Summary

- Add Flutter South India 2026 to the upcoming events data.
- Include the official event website, date, 9:00 AM start time, Chennai location, Namma Flutter community details, and paid-ticket indicator.

## Why

This makes the community-led Flutter and Dart conference discoverable through the Communities event listing.

## User impact

Visitors can discover Flutter South India 2026 in the upcoming events section and follow the official event link for tickets and updates.

## Validation

- `pnpm validate:events` — passed with 79 valid events.
- `git diff --check -- src/data/events.json` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the paid community event “Flutter South India 2026,” scheduled for October 10, 2026, in Chennai.
  * Venue details will be announced when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->