### PR TITLE
feat: add Agentics Foundation SLMs Get Fit Chennai event

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -62,6 +62,10 @@ const config: NextConfig = {
       {
         protocol: 'https',
         hostname: 'www.acdchennai.com'
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.lumacdn.com'
       }
     ]
   }

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -902,6 +902,18 @@
     "communityLogo": "https://podu.pics/5UwCWhjNXF"
   },
   {
+    "eventName": "Agentics Foundation: SLMs gotta get Fit : Chennai Edition",
+    "eventDescription": "Hands-on builder session training 1B–3B Small Language Models with reinforcement learning using OpenEnv and arcade-style game environments.",
+    "eventDate": "2026-08-29",
+    "eventTime": "11:00",
+    "eventEndTime": "15:00",
+    "eventVenue": "TBA",
+    "eventLink": "https://luma.com/nz7x290b",
+    "location": "Chennai",
+    "communityName": "Agentics Foundation",
+    "communityLogo": "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=1,background=white,quality=75,width=400,height=400/uploads/zv/ebcb0e76-408b-4819-bc75-91e33f872785.jpg"
+  },
+  {
     "eventName": "Flutter South India 2026",
     "eventDescription": "A community-led day for Flutter and Dart developers, happening 10 October 2026 in Chennai.",
     "eventDate": "2026-10-10",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -902,7 +902,7 @@
     "communityLogo": "https://podu.pics/5UwCWhjNXF"
   },
   {
-    "eventName": "Agentics Foundation: SLMs gotta get Fit : Chennai Edition",
+    "eventName": "Agentics Foundation: SLMs gotta get Fit: Chennai Edition",
     "eventDescription": "Hands-on builder session training 1B–3B Small Language Models with reinforcement learning using OpenEnv and arcade-style game environments.",
     "eventDate": "2026-08-29",
     "eventTime": "11:00",


### PR DESCRIPTION
## Summary
- Add the single-day Agentics Foundation: SLMs gotta get Fit : Chennai Edition event on 29 Aug 2026 (11:00–15:00, venue TBA)
- Allow `images.lumacdn.com` in Next.js image config so the Luma event artwork can load

## Test plan
- [x] Confirm the event appears on the upcoming events list for 29 Aug 2026
- [x] Confirm community logo loads from the Luma CDN image
- [x] Confirm the event card links to https://luma.com/nz7x290b
- [x] Confirm venue shows as TBA and location as Chennai


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the “Agentics Foundation: SLMs gotta get Fit” event in Chennai on August 29, 2026, from 11:00 to 15:00.
  * Included venue, registration, community, and branding details.

* **Improvements**
  * Enabled images from the event’s image provider to display correctly in event listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->