### PR TITLE
fix: use podu.pics URL for Agentics Foundation event logo

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -62,10 +62,6 @@ const config: NextConfig = {
       {
         protocol: 'https',
         hostname: 'www.acdchennai.com'
-      },
-      {
-        protocol: 'https',
-        hostname: 'images.lumacdn.com'
       }
     ]
   }

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -911,7 +911,7 @@
     "eventLink": "https://luma.com/nz7x290b",
     "location": "Chennai",
     "communityName": "Agentics Foundation",
-    "communityLogo": "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=1,background=white,quality=75,width=400,height=400/uploads/zv/ebcb0e76-408b-4819-bc75-91e33f872785.jpg"
+    "communityLogo": "https://podu.pics/1N9d7sUnDO"
   },
   {
     "eventName": "Flutter South India 2026",


### PR DESCRIPTION
## Summary
- Replace the broken Luma CDN `communityLogo` for the Agentics Foundation: SLMs gotta get Fit Chennai event with the hosted [podu.pics](https://podu.pics/1N9d7sUnDO) image
- Remove the unused `images.lumacdn.com` Next.js image host now that the event no longer depends on it

Fixes #687

## Test plan
- [ ] Confirm the Agentics Foundation event card shows the logo from `https://podu.pics/1N9d7sUnDO`
- [ ] Confirm the logo loads on production (not a broken image)
- [ ] Confirm no other events still need `images.lumacdn.com`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Agentics Foundation event’s community logo to use the correct image URL.
  * Removed an unsupported image source from the application’s allowed image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->