### PR TITLE
feat: add Digital Dreamers Den (D3) Meetup #9

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -936,5 +936,16 @@
     "location": "D.L.F Cyber City (DLF IT Park) Chennai",
     "communityName": "Friends of Figma",
     "communityLogo": "https://podu.pics/8Xan9cRTQL"
+  },
+  {
+    "eventName": "Digital Dreamers Den (D3) Meetup #9",
+    "eventDescription": "Digital Dreamers Den (D3) is a vibrant tech community that brings together AI Full-Stack Developers to build the future. We host events, workshops, and networking opportunities that connect talented engineers with cutting-edge technology and industry leaders.",
+    "eventDate": "2026-09-05",
+    "eventTime": "13:30",
+    "eventVenue": "Freshworks, GLOBAL INFOCITY PARK, Perungudi, Chennai, Tamil Nadu 600096",
+    "eventLink": "https://luma.com/l0fltoqm",
+    "location": "Chennai",
+    "communityName": "Digital Dreamers Den (D3)",
+    "communityLogo": "https://podu.pics/K3Hbv3raG1"
   }
 ]


### PR DESCRIPTION
Adding D3 upcoming meetup on Sept 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Digital Dreamers Den (D3) Meetup `#9` event in Chennai.
  * Event scheduled for September 5, 2026, at Freshworks in Perungudi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->