### PR TITLE
fix: Update Foss united and From Dev to Ops dates and timings

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -963,9 +963,9 @@
   {
     "eventName": "FOSS United Chennai September Meet",
     "eventDescription": "FOSS United Chennai September Month Meetup on Sep 12",
-    "eventDate": "2026-09-12",
-    "eventTime": "09:00",
-    "eventEndTime": "12:30 PM",
+    "eventDate": "2026-09-19",
+    "eventTime": "01:30 PM",
+    "eventEndTime": "05:30 PM",
     "eventVenue": "Ideas2IT Technology Services Private Limited,C50 & C51, Water Works Rd, SIDCO Industrial Estate, Guindy, Chennai, Tamil Nadu 600032",
     "eventLink": "https://fossunited.org/c/chennai/sept-26",
     "location": "Guindy, Chennai",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -940,7 +940,7 @@
   {
     "eventName": "Devops Community Meetup Sep 19",
     "eventDescription": "DevOps Community Meetup sep 19 from Dev to Ops Community, Chennai",
-    "eventDate": "2026-09-19",
+    "eventDate": "2026-09-26",
     "eventTime": "09:30",
     "eventEndTime": "12:30",
     "eventVenue": "Sopra Steria, G-2, Sipcot It Park, 2, Egattur, Tamil Nadu 603103",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -938,8 +938,8 @@
     "communityLogo": "https://podu.pics/8Xan9cRTQL"
   },
   {
-    "eventName": "Devops Community Meetup Sep 19",
-    "eventDescription": "DevOps Community Meetup sep 19 from Dev to Ops Community, Chennai",
+    "eventName": "From Dev to ops Sep Community Meet",
+    "eventDescription": "A chennai born community for DevOps, SRE, Platform Engineering, and Observability.",
     "eventDate": "2026-09-26",
     "eventTime": "09:30",
     "eventEndTime": "12:30",
@@ -962,7 +962,7 @@
   },
   {
     "eventName": "FOSS United Chennai September Meet",
-    "eventDescription": "FOSS United Chennai September Month Meetup on Sep 12",
+    "eventDescription": "Monthly foss united chennai meetup on sept 19th",
     "eventDate": "2026-09-19",
     "eventTime": "01:30 PM",
     "eventEndTime": "05:30 PM",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the DevOps meetup name and description; its September 26, 2026 schedule remains unchanged.
  * Updated the FOSS United Chennai meetup description; its September 19, 2026 afternoon schedule remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->