### PR TITLE
feat: Add DevFest Chennai 2026 event details

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1001,7 +1001,7 @@
     "eventDescription": "DevFest is one of the largest and most inclusive community-led technology conferences worldwide! Every year, Google Developer Groups host DevFests, where attendees explore developer tools, learn from Google Developer Experts, and connect with other tech enthusiasts from their local community.",
     "eventDate": "2026-10-17",
     "eventTime": "09:00",
-    "eventVenue": "IIT Madras Research Park, MGR Film City Road, Chennai, 600113",
+    "eventVenue": "IIT Madras Research Park, MGR Film City Road, Kanagam, Tharamani, Chennai – 600 113",
     "eventLink": "https://devfest.gdgchennai.in/",
     "location": "IITM Research Park,Chennai",
     "communityName": "Google Developer Group Chennai",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -995,5 +995,17 @@
     "location": "Guindy,Chennai",
     "communityName": "HackBriven",
     "communityLogo": "https://podu.pics/MXLhZmq7vc"
+  },
+    {
+    "eventName": "DevFest 2026 Chennai",
+    "eventDescription": "DevFest is one of the largest and most inclusive community-led technology conferences worldwide! Every year, Google Developer Groups host DevFests, where attendees explore developer tools, learn from Google Developer Experts, and connect with other tech enthusiasts from their local community.",
+    "eventDate": "2026-10-17",
+    "eventTime": "09:00",
+    "eventVenue": "IIT Madras Research Park, MGR Film City Road, Chennai, 600113",
+    "eventLink": "https://devfest.gdgchennai.in/",
+    "location": "IITM Research Park,Chennai",
+    "communityName": "Google Developer Group Chennai",
+    "communityLogo": "https://i.ibb.co/ynkrJnD4/gdglogo-0229df09.png",
+    "paid": true
   }
 ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -996,7 +996,7 @@
     "communityName": "HackBriven",
     "communityLogo": "https://podu.pics/MXLhZmq7vc"
   },
-    {
+  {
     "eventName": "DevFest 2026 Chennai",
     "eventDescription": "DevFest is one of the largest and most inclusive community-led technology conferences worldwide! Every year, Google Developer Groups host DevFests, where attendees explore developer tools, learn from Google Developer Experts, and connect with other tech enthusiasts from their local community.",
     "eventDate": "2026-10-17",


### PR DESCRIPTION
Added new event 'DevFest 2026 Chennai' with details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Events**
  * Added DevFest 2026 Chennai, a paid event on October 17, 2026, at IIT Madras Research Park in Kanagam, Tharamani.
  * Included registration details and a link to the official event website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->