### PR TITLE
Add OpenSearch event for September 12

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1019,5 +1019,17 @@
     "communityName": "Google Developer Group Chennai",
     "communityLogo": "https://i.ibb.co/ynkrJnD4/gdglogo-0229df09.png",
     "paid": true
+  },
+  {
+    "eventName": "OpenSearch × AAIF: Where Search Meets Agents",
+    "eventDescription": "OpenSearch and the Agentic AI Foundation are helping shape the future of how intelligent tools and AI agents are built, discovered, and scaled. Join us for an exciting community gathering featuring talks from hands-on practitioners, industry experts, and community members sharing their knowledge and real-world experiences",
+    "eventDate": "2026-09-12",
+    "eventTime": "10:00 AM",
+    "eventEndTime": "01:00 PM",
+    "eventVenue": "Freshworks, GLOBAL INFOCITY PARK, Perungudi, Chennai, Tamil Nadu 600096",
+    "eventLink": "https://www.meetup.com/opensearch-project-chennai/events/316386483/",
+    "location": "Perungudi,Chennai",
+    "communityName": "OpenSearch User Group Chennai",
+    "communityLogo": "https://res.cloudinary.com/dfhtr1rwo/image/upload/v1762066985/opensearch_logo_hg3k8s.png"
   }
 ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1026,7 +1026,7 @@
     "eventDate": "2026-09-12",
     "eventTime": "10:00 AM",
     "eventEndTime": "01:00 PM",
-    "eventVenue": "Freshworks, GLOBAL INFOCITY PARK, Perungudi, Chennai, Tamil Nadu 600096",
+    "eventVenue": "Freshworks, Vijay Shanthi Block-B, GLOBAL INFOCITY PARK, 40, MGR Main Rd, Kodandarama Nagar, Perungudi, Chennai, Tamil Nadu 600096",
     "eventLink": "https://www.meetup.com/opensearch-project-chennai/events/316386483/",
     "location": "Perungudi,Chennai",
     "communityName": "OpenSearch User Group Chennai",


### PR DESCRIPTION
This pull request adds a new event to the events data. The update introduces details for the "OpenSearch × AAIF: Where Search Meets Agents" event, including its description, date, venue, and associated community.

**Event Data Update:**

* Added a new event entry for "OpenSearch × AAIF: Where Search Meets Agents" with full details such as description, date, time, venue, link, location, and community information in `src/data/events.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the “OpenSearch × AAIF: Where Search Meets Agents” event listing with the complete Freshworks venue address, including Vijay Shanthi Block-B, 40 MGR Main Road, and Kodandarama Nagar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->